### PR TITLE
Use patch -p1 instead of patch -fp1

### DIFF
--- a/mk/support/pkg/pkg.sh
+++ b/mk/support/pkg/pkg.sh
@@ -130,7 +130,7 @@ pkg_patch () {
     for patch in "$pkg_dir"/patch/"$pkg"_*.patch; do # lexical order
         case "$patch" in
             *_\*.patch) ;;
-            *) in_dir "$1" patch -fp1 < "$patch" ;;
+            *) in_dir "$1" patch -p1 < "$patch" ;;
         esac
     done
 }
@@ -162,15 +162,6 @@ pkg_save_patch () {
     echo "Wrote $pkg_dir/patch/${pkg}_$patch_name.patch"
 
     pkg_remove_tmp_fetch_dir
-}
-
-pkg_patch () {
-    for patch in "$pkg_dir"/patch/"$pkg"_*.patch; do # lexical order
-        case "$patch" in
-            *_\*.patch) ;;
-            *) in_dir "$1" patch -fp1 < "$patch" ;;
-        esac
-    done
 }
 
 pkg_fetch_git () {


### PR DESCRIPTION
See issue #6666.  -f is not in POSIX, and if the patch is valid, then
-p1 works just fine.

- [ ] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
<Please fill in the description of your pull request here. Thank you for your contribution!>
